### PR TITLE
change default color

### DIFF
--- a/Icon.cs
+++ b/Icon.cs
@@ -8,7 +8,7 @@ namespace Feather.Blazor
     public class Icon : ComponentBase
     {
         [Parameter]
-        public string Color { get; set; } = "#ffffff";
+        public string Color { get; set; } = "currentColor";
         [Parameter]
         public float StrokeWidth { get; set; } = 1.5f;
         [Parameter]


### PR DESCRIPTION
By default icons are invisible. I think, that `Color` parameter must have default value to `"currentColor"`